### PR TITLE
mseznec/export weights for ft fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Large language models (LLMs) show excellent performance but are compute- and mem
 conda create -n smoothquant python=3.8
 conda activate smoothquant
 pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu113
-pip install transformers accelerate datasets
+pip install transformers accelerate datasets zstandard
 
 python setup.py install
 ```

--- a/smoothquant/calibration.py
+++ b/smoothquant/calibration.py
@@ -57,7 +57,6 @@ def get_static_decoder_layer_scales(model,
                                     dataset_path,
                                     num_samples=512,
                                     seq_len=512,
-                                    return_act_scales_dict=False,
                                     ):
     model.eval()
     device = next(model.parameters()).device
@@ -99,9 +98,6 @@ def get_static_decoder_layer_scales(model,
     for hook in hooks:
         hook.remove()
 
-    if return_act_scales_dict:
-        return act_dict
-
     decoder_layer_scales = []
     for idx in range(model.config.num_hidden_layers):
         scale_dict = {}
@@ -121,4 +117,4 @@ def get_static_decoder_layer_scales(model,
             f"model.decoder.layers.{idx}.fc2"]["input"] / 127
         decoder_layer_scales.append(scale_dict)
 
-    return decoder_layer_scales
+    return decoder_layer_scales, act_dict


### PR DESCRIPTION
- get_static_decoder_layer_scales always return raw scaling factors.
- Rename scales-only option to export-FT. It both exports the model (as
  a standard HuggingFace model) and the scaling factors.
- Change the output filename creation procedure. When having a path
  with a final slash (ex: path/to/model/) the model name was empty.